### PR TITLE
Add handling for escape character for in-table embedded images

### DIFF
--- a/scripts/copyNotes.ts
+++ b/scripts/copyNotes.ts
@@ -170,7 +170,7 @@ for (const { full, relative, dest } of FILE_LIST) {
   const content = fs.readFileSync(full, 'utf-8');
 
   // Detect embedded images and copy assets
-  const imageRegex = /!\[\[([^|\]]+)/g;
+  const imageRegex = /!\[\[([^|\\\]]+)/g;
   let match: RegExpExecArray | null;
   while ((match = imageRegex.exec(content)) !== null) {
     copyAssetIfExists(match[1]);


### PR DESCRIPTION
Resolves #53

Only in-table images had issues, links were fine.