### PR TITLE
Add css to use 2 space indentation in shiki codeblocks

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -158,3 +158,9 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* sets tab size to 2 spaces in shiki code blocks */
+pre.shiki code {
+  tab-size: 2;
+  -moz-tab-size: 2;
+}


### PR DESCRIPTION
Fixes #57 

Not exactly a fix but sets the default indentation to 2 spaces.

Explore turning this into a config setting in the future.